### PR TITLE
Fix timetable time update issue

### DIFF
--- a/server/models/PrayerTime.js
+++ b/server/models/PrayerTime.js
@@ -54,7 +54,8 @@ const prayerTimeSchema = new mongoose.Schema(
     updatedBy: {
       type: mongoose.Schema.Types.ObjectId,
       ref: 'User',
-      required: true,
+      required: false,
+      default: null,
     },
   },
   {

--- a/src/App.js
+++ b/src/App.js
@@ -169,17 +169,6 @@ function App() {
                 break;
               }
 
-              // Try to refresh token if needed
-              try {
-                await apiService.refreshToken();
-              } catch (refreshError) {
-                console.log('Token refresh failed, user needs to login again');
-                notify('Session expired. Please log in again.', {
-                  type: 'error',
-                });
-                break;
-              }
-
               const result = await apiService.updatePrayerTimes(payload.times);
               if (result.success) {
                 // Update local prayer times state


### PR DESCRIPTION
Fix: Enable timetable time updates by removing a redundant token refresh and making `updatedBy` optional in the PrayerTime model.

The previous client-side token refresh was brittle and could prematurely block updates, while the `updatedBy` field's strict requirement prevented valid updates or initial creations from passing schema validation.

---
<a href="https://cursor.com/background-agent?bcId=bc-8497a5c2-5b52-48a6-8c01-37171798103e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-8497a5c2-5b52-48a6-8c01-37171798103e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

